### PR TITLE
Upcase WKT geometry types as per the standard

### DIFF
--- a/lib/geometry.ex
+++ b/lib/geometry.ex
@@ -313,13 +313,13 @@ defmodule Geometry do
   ## Examples
 
       iex> Geometry.to_ewkt(PointZ.new(1.1, 2.2, 3.3, 4211))
-      "SRID=4211;Point Z (1.1 2.2 3.3)"
+      "SRID=4211;POINT Z (1.1 2.2 3.3)"
 
       iex> Geometry.to_ewkt(LineString.new([Point.new(1, 2), Point.new(3, 4)], 3825))
-      "SRID=3825;LineString (1 2, 3 4)"
+      "SRID=3825;LINESTRING (1 2, 3 4)"
 
       iex> Geometry.to_ewkt(Point.new(1, 2))
-      "Point (1 2)"
+      "POINT (1 2)"
   """
   @spec to_ewkt(Geometry.t()) :: wkt()
   def to_ewkt(%{srid: 0} = geometry), do: to_wkt(geometry)
@@ -332,13 +332,13 @@ defmodule Geometry do
   ## Examples
 
       iex> Geometry.to_wkt(PointZ.new(1.1, 2.2, 3.3))
-      "Point Z (1.1 2.2 3.3)"
+      "POINT Z (1.1 2.2 3.3)"
 
       iex> Geometry.to_wkt(LineString.new([Point.new(1, 2), Point.new(3, 4)]))
-      "LineString (1 2, 3 4)"
+      "LINESTRING (1 2, 3 4)"
 
       iex> Geometry.to_wkt(Point.new(1, 2))
-      "Point (1 2)"
+      "POINT (1 2)"
   """
   @spec to_wkt(Geometry.t()) :: wkt()
   def to_wkt(geometry), do: Encoder.WKT.to_wkt(geometry)

--- a/lib/geometry/protocols.ex
+++ b/lib/geometry/protocols.ex
@@ -542,7 +542,7 @@ defmodule Geometry.Protocols do
         def to_wkt(%{coordinates: []}) do
           unquote(
             binary([
-              "Point",
+              "POINT",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -552,7 +552,7 @@ defmodule Geometry.Protocols do
         def to_wkt(unquote(match(:coordinates, dim))) do
           unquote(
             binary([
-              "Point",
+              "POINT",
               @wkt_types[dim],
               "(",
               coordinate_to_string(dim),
@@ -565,7 +565,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "Point",
+              "POINT",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -576,7 +576,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "Point",
+              "POINT",
               @wkt_types[dim],
               "(",
               coordinate_to_string(dim),
@@ -594,7 +594,7 @@ defmodule Geometry.Protocols do
         def to_wkt(%{path: []}) do
           unquote(
             binary([
-              "LineString",
+              "LINESTRING",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -606,7 +606,7 @@ defmodule Geometry.Protocols do
 
           unquote(
             binary([
-              "LineString",
+              "LINESTRING",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),
@@ -619,7 +619,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "LineString",
+              "LINESTRING",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -632,7 +632,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "LineString",
+              "LINESTRING",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),
@@ -650,7 +650,7 @@ defmodule Geometry.Protocols do
         def to_wkt(%{rings: []}) do
           unquote(
             binary([
-              "Polygon",
+              "POLYGON",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -662,7 +662,7 @@ defmodule Geometry.Protocols do
 
           unquote(
             binary([
-              "Polygon",
+              "POLYGON",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),
@@ -675,7 +675,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "Polygon",
+              "POLYGON",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -688,7 +688,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "Polygon",
+              "POLYGON",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),
@@ -706,7 +706,7 @@ defmodule Geometry.Protocols do
         def to_wkt(%{points: []}) do
           unquote(
             binary([
-              "MultiPoint",
+              "MULTIPOINT",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -718,7 +718,7 @@ defmodule Geometry.Protocols do
 
           unquote(
             binary([
-              "MultiPoint",
+              "MULTIPOINT",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),
@@ -731,7 +731,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "MultiPoint",
+              "MULTIPOINT",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -744,7 +744,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "MultiPoint",
+              "MULTIPOINT",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),
@@ -762,7 +762,7 @@ defmodule Geometry.Protocols do
         def to_wkt(%{line_strings: []}) do
           unquote(
             binary([
-              "MultiLineString",
+              "MULTILINESTRING",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -774,7 +774,7 @@ defmodule Geometry.Protocols do
 
           unquote(
             binary([
-              "MultiLineString",
+              "MULTILINESTRING",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),
@@ -787,7 +787,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "MultiLineString",
+              "MULTILINESTRING",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -800,7 +800,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "MultiLineString",
+              "MULTILINESTRING",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),
@@ -818,7 +818,7 @@ defmodule Geometry.Protocols do
         def to_wkt(%{polygons: []}) do
           unquote(
             binary([
-              "MultiPolygon",
+              "MULTIPOLYGON",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -830,7 +830,7 @@ defmodule Geometry.Protocols do
 
           unquote(
             binary([
-              "MultiPolygon",
+              "MULTIPOLYGON",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),
@@ -843,7 +843,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "MultiPolygon",
+              "MULTIPOLYGON",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -856,7 +856,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "MultiPolygon",
+              "MULTIPOLYGON",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),
@@ -874,7 +874,7 @@ defmodule Geometry.Protocols do
         def to_wkt(%{geometries: []}) do
           unquote(
             binary([
-              "GeometryCollection",
+              "GEOMETRYCOLLECTION",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -886,7 +886,7 @@ defmodule Geometry.Protocols do
 
           unquote(
             binary([
-              "GeometryCollection",
+              "GEOMETRYCOLLECTION",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),
@@ -899,7 +899,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "GeometryCollection",
+              "GEOMETRYCOLLECTION",
               @wkt_types[dim],
               "EMPTY"
             ])
@@ -912,7 +912,7 @@ defmodule Geometry.Protocols do
           unquote(
             binary([
               srid_to_string(),
-              "GeometryCollection",
+              "GEOMETRYCOLLECTION",
               @wkt_types[dim],
               "(",
               quote(do: data :: binary),

--- a/test/geometry/geometry_collection_test.exs
+++ b/test/geometry/geometry_collection_test.exs
@@ -864,12 +864,12 @@ defmodule Geometry.GeometryCollectionTest do
 
   defp wkt_parts(name, dim \\ nil, data \\ [], srid \\ "")
 
-  defp wkt_parts(name, _dim, [], ""), do: [~r/#{name}\sEMPTY/]
+  defp wkt_parts(name, _dim, [], ""), do: [~r/#{String.upcase(name)}\sEMPTY/]
 
-  defp wkt_parts(name, _dim, [], srid), do: [~r/SRID=#{srid};#{name}\sEMPTY/]
+  defp wkt_parts(name, _dim, [], srid), do: [~r/SRID=#{srid};#{String.upcase(name)}\sEMPTY/]
 
   defp wkt_parts(name, dim, data, srid) do
-    [~r/#{srid(srid)}#{name}\s\(.*\)/ | wkt_parts_regex(dim, data, srid)]
+    [~r/#{srid(srid)}#{String.upcase(name)}\s\(.*\)/ | wkt_parts_regex(dim, data, srid)]
   end
 
   defp wkt_parts_regex(dim, data, srid) do
@@ -882,12 +882,12 @@ defmodule Geometry.GeometryCollectionTest do
 
   defp wkt(name, dim \\ nil, data \\ [], srid \\ "")
 
-  defp wkt(name, _dim, [], ""), do: "#{name} EMPTY"
+  defp wkt(name, _dim, [], ""), do: "#{String.upcase(name)} EMPTY"
 
-  defp wkt(name, _dim, [], srid), do: "SRID=#{srid};#{name} EMPTY"
+  defp wkt(name, _dim, [], srid), do: "SRID=#{srid};#{String.upcase(name)} EMPTY"
 
   defp wkt(name, dim, data, srid) do
-    "#{srid(srid)}#{name} (#{dim |> wkt_parts_text(data, srid) |> Enum.join(", ")})"
+    "#{srid(srid)}#{String.upcase(name)} (#{dim |> wkt_parts_text(data, srid) |> Enum.join(", ")})"
   end
 
   defp wkt_parts_text(dim, data, srid) do

--- a/test/geometry/line_string_test.exs
+++ b/test/geometry/line_string_test.exs
@@ -586,16 +586,16 @@ defmodule Geometry.LineStringTest do
 
   defp wkt(name, data \\ [], srid \\ "")
 
-  defp wkt(name, [], ""), do: "#{name} EMPTY"
+  defp wkt(name, [], ""), do: "#{String.upcase(name)} EMPTY"
 
-  defp wkt(name, [], srid), do: "SRID=#{srid};#{name} EMPTY"
+  defp wkt(name, [], srid), do: "SRID=#{srid};#{String.upcase(name)} EMPTY"
 
   defp wkt(name, data, srid) do
     coordinates = Enum.map_join(data, ", ", fn point -> Enum.join(point, @blank) end)
 
     srid = if srid == "", do: "", else: "SRID=#{srid};"
 
-    "#{srid}#{name} (#{coordinates})"
+    "#{srid}#{String.upcase(name)} (#{coordinates})"
   end
 
   defp line(module, data, dim, srid \\ 0) do

--- a/test/geometry/multi_line_string_test.exs
+++ b/test/geometry/multi_line_string_test.exs
@@ -725,9 +725,9 @@ defmodule Geometry.MultiLineStringTest do
 
   defp wkt(name, data \\ [], srid \\ "")
 
-  defp wkt(name, [], ""), do: "#{name} EMPTY"
+  defp wkt(name, [], ""), do: "#{String.upcase(name)} EMPTY"
 
-  defp wkt(name, [], srid), do: "SRID=#{srid};#{name} EMPTY"
+  defp wkt(name, [], srid), do: "SRID=#{srid};#{String.upcase(name)} EMPTY"
 
   defp wkt(name, data, srid) do
     coordinates =
@@ -739,7 +739,7 @@ defmodule Geometry.MultiLineStringTest do
       end)
       |> in_brackets()
 
-    "#{srid(srid)}#{name} #{coordinates}"
+    "#{srid(srid)}#{String.upcase(name)} #{coordinates}"
   end
 
   defp srid(""), do: ""

--- a/test/geometry/multi_point_test.exs
+++ b/test/geometry/multi_point_test.exs
@@ -655,16 +655,16 @@ defmodule Geometry.MultiPointTest do
 
   defp wkt(name, data \\ [], srid \\ "")
 
-  defp wkt(name, [], ""), do: "#{name} EMPTY"
+  defp wkt(name, [], ""), do: "#{String.upcase(name)} EMPTY"
 
-  defp wkt(name, [], srid), do: "SRID=#{srid};#{name} EMPTY"
+  defp wkt(name, [], srid), do: "SRID=#{srid};#{String.upcase(name)} EMPTY"
 
   defp wkt(name, data, srid) do
     coordinates = Enum.map_join(data, ", ", fn point -> Enum.join(point, @blank) end)
 
     srid = if srid == "", do: "", else: "SRID=#{srid};"
 
-    "#{srid}#{name} (#{coordinates})"
+    "#{srid}#{String.upcase(name)} (#{coordinates})"
   end
 
   defp multi_point(module, data, dim, srid \\ 0, to_float \\ false) do

--- a/test/geometry/multi_polygon_test.exs
+++ b/test/geometry/multi_polygon_test.exs
@@ -753,12 +753,12 @@ defmodule Geometry.MultiPolygonTest do
 
   defp wkt(name, data \\ [], srid \\ "")
 
-  defp wkt(name, [], ""), do: "#{name} EMPTY"
+  defp wkt(name, [], ""), do: "#{String.upcase(name)} EMPTY"
 
-  defp wkt(name, [], srid), do: "SRID=#{srid};#{name} EMPTY"
+  defp wkt(name, [], srid), do: "SRID=#{srid};#{String.upcase(name)} EMPTY"
 
   defp wkt(name, data, srid) do
-    "#{srid(srid)}#{name} #{wkt_data(data)}"
+    "#{srid(srid)}#{String.upcase(name)} #{wkt_data(data)}"
   end
 
   defp wkt_data([x | _] = point) when is_number(x), do: Enum.join(point, @blank)

--- a/test/geometry/point_test.exs
+++ b/test/geometry/point_test.exs
@@ -624,7 +624,7 @@ defmodule Geometry.PointNewTest do
         @describetag :wkt
 
         test "returns a point from WKT" do
-          wkt = "#{unquote(text)} (#{unquote(Enum.join(data[:term], @blank))})"
+          wkt = "#{unquote(String.upcase(text))} (#{unquote(Enum.join(data[:term], @blank))})"
           point = unquote(module).new(unquote(data[:term]))
 
           assert Geometry.from_wkt!(wkt) == point
@@ -635,14 +635,14 @@ defmodule Geometry.PointNewTest do
         @describetag :wkt
 
         test "returns WKT for a point" do
-          wkt = "#{unquote(text)} (#{unquote(Enum.join(data[:term], @blank))})"
+          wkt = "#{unquote(String.upcase(text))} (#{unquote(Enum.join(data[:term], @blank))})"
           point = unquote(module).new(unquote(data[:term]))
 
           assert Geometry.to_wkt(point) == wkt
         end
 
         test "returns WKT for an empty point" do
-          wkt = "#{unquote(text)} EMPTY"
+          wkt = "#{unquote(String.upcase(text))} EMPTY"
           point = unquote(module).new()
 
           assert Geometry.to_wkt(point) == wkt
@@ -653,14 +653,14 @@ defmodule Geometry.PointNewTest do
         @describetag :wkt
 
         test "returns a point from WKT" do
-          wkt = "#{unquote(text)} (#{unquote(Enum.join(data[:term], @blank))})"
+          wkt = "#{unquote(String.upcase(text))} (#{unquote(Enum.join(data[:term], @blank))})"
           point = unquote(module).new(unquote(data[:term]))
 
           assert Geometry.from_ewkt(wkt) == {:ok, point}
         end
 
         test "returns an empty point from WKT" do
-          wkt = "#{unquote(text)} empty"
+          wkt = "#{unquote(String.upcase(text))} empty"
           point = unquote(module).new()
 
           assert Geometry.from_ewkt(wkt) == {:ok, point}
@@ -668,7 +668,7 @@ defmodule Geometry.PointNewTest do
 
         test "returns a point from WKT with srid" do
           wkt =
-            "SRID=#{unquote(srid)};#{unquote(text)} (#{unquote(Enum.join(data[:term], @blank))})"
+            "SRID=#{unquote(srid)};#{unquote(String.upcase(text))} (#{unquote(Enum.join(data[:term], @blank))})"
 
           point = unquote(module).new(unquote(data[:term]), unquote(srid))
 
@@ -676,7 +676,7 @@ defmodule Geometry.PointNewTest do
         end
 
         test "returns an empty point from WKT with srid" do
-          wkt = "SRID=#{unquote(srid)};#{unquote(text)} empty"
+          wkt = "SRID=#{unquote(srid)};#{unquote(String.upcase(text))} empty"
           point = unquote(module).new() |> Map.put(:srid, unquote(srid))
 
           assert Geometry.from_ewkt(wkt) == {:ok, point}
@@ -687,7 +687,7 @@ defmodule Geometry.PointNewTest do
         @describetag :wkt
 
         test "returns a point from WKT" do
-          wkt = "#{unquote(text)} (#{unquote(Enum.join(data[:term], @blank))})"
+          wkt = "#{unquote(String.upcase(text))} (#{unquote(Enum.join(data[:term], @blank))})"
           point = unquote(module).new(unquote(data[:term]))
 
           assert Geometry.from_ewkt!(wkt) == point
@@ -699,7 +699,7 @@ defmodule Geometry.PointNewTest do
 
         test "returns WKT for a point" do
           wkt =
-            "SRID=#{unquote(srid)};#{unquote(text)} (#{unquote(Enum.join(data[:term], @blank))})"
+            "SRID=#{unquote(srid)};#{unquote(String.upcase(text))} (#{unquote(Enum.join(data[:term], @blank))})"
 
           point = unquote(module).new(unquote(data[:term]), unquote(srid))
 
@@ -707,7 +707,7 @@ defmodule Geometry.PointNewTest do
         end
 
         test "returns WKT for an empty point" do
-          wkt = "SRID=#{unquote(srid)};#{unquote(text)} EMPTY"
+          wkt = "SRID=#{unquote(srid)};#{unquote(String.upcase(text))} EMPTY"
           point = unquote(module).new() |> Map.put(:srid, unquote(srid))
 
           assert Geometry.to_ewkt(point) == wkt

--- a/test/geometry/polygon_test.exs
+++ b/test/geometry/polygon_test.exs
@@ -628,9 +628,9 @@ defmodule Geometry.PolygonTest do
 
   defp wkt(name, data \\ [], srid \\ "")
 
-  defp wkt(name, [], ""), do: "#{name} EMPTY"
+  defp wkt(name, [], ""), do: "#{String.upcase(name)} EMPTY"
 
-  defp wkt(name, [], srid), do: "SRID=#{srid};#{name} EMPTY"
+  defp wkt(name, [], srid), do: "SRID=#{srid};#{String.upcase(name)} EMPTY"
 
   defp wkt(name, data, srid) do
     rings =
@@ -641,7 +641,7 @@ defmodule Geometry.PolygonTest do
 
     srid = if srid == "", do: "", else: "SRID=#{srid};"
 
-    "#{srid}#{name} (#{rings})"
+    "#{srid}#{String.upcase(name)} (#{rings})"
   end
 
   defp polygon(module, data, dim, srid \\ 0) do


### PR DESCRIPTION
As noted in the [standard](https://docs.ogc.org/is/18-010r11/18-010r11.pdf) and also nicely summarized [here](https://libgeos.org/specifications/wkt/) and [here](https://www.ibm.com/docs/de/db2/11.5.x?topic=formats-well-known-text-wkt-format), geometric types in WKT are expected to be all upper case.

Most parsers are liberal about this, but some are not, such as the one that powers https://wktviewer.com/ which requires UPCASE and throws an error otherwise:

![Screenshot_20250701_110657](https://github.com/user-attachments/assets/c791c556-0594-49e0-aa2f-d90250ea3ec7)

This PR brings the geometry library more into line with the WKT standard regarding case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * All geometry type names in WKT and EWKT string outputs are now consistently displayed in uppercase (e.g., "POINT", "LINESTRING", "POLYGON") instead of mixed case.

* **Tests**
  * Updated test cases to expect uppercase geometry type names in WKT/EWKT outputs, ensuring consistency with the new formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->