### PR TITLE
Bugfix: Support all geometry types in GeometryCollections in wkb

### DIFF
--- a/lib/geometry/decoder/wkb.ex
+++ b/lib/geometry/decoder/wkb.ex
@@ -623,9 +623,15 @@ defmodule Geometry.Decoder.WKB do
         {data, rest} =
           Enum.map_reduce(List.duplicate(0, length), bin, fn _ignore, bin ->
             case collection(unquote(geo.dim), unquote(geo.endian), bin) do
-              {:ok, :point, bin} ->
-                case point(unquote(geo.dim), unquote(geo.endian), srid, bin) do
-                  {:ok, point, bin} -> {point, bin}
+              {:ok, :geometry_collection, bin} ->
+                case geometry_collection(unquote(geo.dim), unquote(geo.endian), srid, bin) do
+                  {:ok, geometry_collection, bin} -> {geometry_collection, bin}
+                  error -> throw(error)
+                end
+
+              {:ok, :line_string, bin} ->
+                case line_string(unquote(geo.dim), unquote(geo.endian), srid, bin) do
+                  {:ok, line_string, bin} -> {line_string, bin}
                   error -> throw(error)
                 end
 
@@ -635,9 +641,21 @@ defmodule Geometry.Decoder.WKB do
                   error -> throw(error)
                 end
 
-              {:ok, :line_string, bin} ->
-                case line_string(unquote(geo.dim), unquote(geo.endian), srid, bin) do
-                  {:ok, line_string, bin} -> {line_string, bin}
+              {:ok, :multi_point, bin} ->
+                case multi_point(unquote(geo.dim), unquote(geo.endian), srid, bin) do
+                  {:ok, multi_point, bin} -> {multi_point, bin}
+                  error -> throw(error)
+                end
+
+              {:ok, :multi_polygon, bin} ->
+                case multi_polygon(unquote(geo.dim), unquote(geo.endian), srid, bin) do
+                  {:ok, multi_polygon, bin} -> {multi_polygon, bin}
+                  error -> throw(error)
+                end
+
+              {:ok, :point, bin} ->
+                case point(unquote(geo.dim), unquote(geo.endian), srid, bin) do
+                  {:ok, point, bin} -> {point, bin}
                   error -> throw(error)
                 end
 


### PR DESCRIPTION
I ran across an SQL function in PostGIS that returns a multilinestring inside a geometry collection. This causes a parse error in Geometry even though it is correct.

This PR includes a test with that return data, in both wkb and wkt, and fixes it.

It also fixes a small copy/paste issue where "point" was used repeatedly when really there are lines and polygons.